### PR TITLE
feature/add-hash-table

### DIFF
--- a/pkg/datastructures/hashtable/main.go
+++ b/pkg/datastructures/hashtable/main.go
@@ -1,0 +1,62 @@
+package hashtable
+
+type (
+	 item struct {
+		next *item 
+		key string
+		value string
+	}
+	bucket struct {
+		node *item
+		length int
+	}
+)
+
+var table = make([]*bucket, 100)
+
+// hash function, adds up the rune values of the characters in the key 
+func hash(key string) int {
+	sum := 0
+	for _, v := range key {
+		sum += int(v)
+	}
+	sum %= 100
+	return sum
+}
+
+func getItemByKey (key string, bucketItem *item) *item {
+	if	bucketItem.key == key {
+		return bucketItem
+	}
+	return getItemByKey(key, bucketItem.next)
+}
+
+// GetValueFromBucket get the value of the key 
+func GetValueFromBucket(key string) string {
+	index:= hash(key)
+	bucketItem:= table[index].node
+	item:= getItemByKey(key, bucketItem)
+	return item.value
+}
+
+func getItem(item *item) *item {
+	return item.next
+}
+
+// Insert a key value pair into the table
+func Insert(key string, value string) {
+	indexToInsert:= hash(key)
+	newItem := item {nil, key, value}
+	if table[indexToInsert] == nil {
+		// new entry
+		newBucket := bucket {&newItem, 1}
+		table[indexToInsert] = &newBucket
+	} else  {
+		for i:= table[indexToInsert].length; i >= 0; i-- {
+			getItem(table[indexToInsert].node)
+		}
+		// add next linked item to the bucket
+		table[indexToInsert].node.next = &newItem
+		table[indexToInsert].length++
+	}
+}

--- a/pkg/datastructures/hashtable/main.go
+++ b/pkg/datastructures/hashtable/main.go
@@ -17,10 +17,10 @@ var table = make([]*bucket, 100)
 // hash function, adds up the rune values of the characters in the key
 func hash(key string) int {
 	sum := 0
-	for _, v := range key {
-		sum += int(v)
+	for i, v := range key {
+		sum += int(v) + i
 	}
-	sum %= 100
+	sum %= 97
 	return sum
 }
 

--- a/pkg/datastructures/hashtable/main.go
+++ b/pkg/datastructures/hashtable/main.go
@@ -1,20 +1,20 @@
 package hashtable
 
 type (
-	 item struct {
-		next *item 
-		key string
+	item struct {
+		next  *item
+		key   string
 		value string
 	}
 	bucket struct {
-		node *item
+		node   *item
 		length int
 	}
 )
 
 var table = make([]*bucket, 100)
 
-// hash function, adds up the rune values of the characters in the key 
+// hash function, adds up the rune values of the characters in the key
 func hash(key string) int {
 	sum := 0
 	for _, v := range key {
@@ -24,31 +24,31 @@ func hash(key string) int {
 	return sum
 }
 
-func getItemByKey (key string, bucketItem *item) *item {
-	if	bucketItem.key == key {
+func getItemByKey(key string, bucketItem *item) *item {
+	if bucketItem.key == key {
 		return bucketItem
 	}
 	return getItemByKey(key, bucketItem.next)
 }
 
-// GetValueFromBucket get the value of the key 
+// GetValueFromBucket get the value of the key
 func GetValueFromBucket(key string) string {
-	index:= hash(key)
-	bucketItem:= table[index].node
-	item:= getItemByKey(key, bucketItem)
+	index := hash(key)
+	bucketItem := table[index].node
+	item := getItemByKey(key, bucketItem)
 	return item.value
 }
 
 // Insert a key value pair into the table
 func Insert(key string, value string) {
-	indexToInsert:= hash(key)
-	newItem := item {nil, key, value}
+	indexToInsert := hash(key)
+	newItem := item{nil, key, value}
 	if table[indexToInsert] == nil {
 		// new entry
-		newBucket := bucket {&newItem, 1}
+		newBucket := bucket{&newItem, 1}
 		table[indexToInsert] = &newBucket
-	} else  {
-		// add next linked item to the bucket
+	} else {
+		// add next free linked item to the bucket
 		table[indexToInsert].node.next = &newItem
 		table[indexToInsert].length++
 	}

--- a/pkg/datastructures/hashtable/main.go
+++ b/pkg/datastructures/hashtable/main.go
@@ -39,10 +39,6 @@ func GetValueFromBucket(key string) string {
 	return item.value
 }
 
-func getItem(item *item) *item {
-	return item.next
-}
-
 // Insert a key value pair into the table
 func Insert(key string, value string) {
 	indexToInsert:= hash(key)
@@ -52,9 +48,6 @@ func Insert(key string, value string) {
 		newBucket := bucket {&newItem, 1}
 		table[indexToInsert] = &newBucket
 	} else  {
-		for i:= table[indexToInsert].length; i >= 0; i-- {
-			getItem(table[indexToInsert].node)
-		}
 		// add next linked item to the bucket
 		table[indexToInsert].node.next = &newItem
 		table[indexToInsert].length++

--- a/pkg/datastructures/hashtable/main_test.go
+++ b/pkg/datastructures/hashtable/main_test.go
@@ -17,19 +17,20 @@ func insertKeys() {
 }
 
 func TestGetValueFromBucket(t *testing.T) {
-	golangValue:= GetValueFromBucket("GOLANG")
+	// tests for GetValueFromBucket
+	golangValue := GetValueFromBucket("GOLANG")
 	if golangValue != "001" {
 		t.Errorf("Value for GOLANG should be 001, got value = %v", golangValue)
 	}
-	langgoValue:= GetValueFromBucket("LANGGO")
+	langgoValue := GetValueFromBucket("LANGGO")
 	if langgoValue != "100" {
 		t.Errorf("Value for GOLANG should be 100, got value = %v", langgoValue)
 	}
-	goValue:= GetValueFromBucket("GO")
+	goValue := GetValueFromBucket("GO")
 	if goValue != "002" {
 		t.Errorf("Value for GOLANG should be 002, got value = %v", goValue)
 	}
-	hashValue:= GetValueFromBucket("HASH")
+	hashValue := GetValueFromBucket("HASH")
 	if hashValue != "003" {
 		t.Errorf("Value for GOLANG should be 003, got value = %v", hashValue)
 	}

--- a/pkg/datastructures/hashtable/main_test.go
+++ b/pkg/datastructures/hashtable/main_test.go
@@ -1,0 +1,36 @@
+package hashtable
+
+import (
+	"github.com/wednesday-solutions/golang-algorithm-club/pkg/utl"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	utl.SetupTests(m, insertKeys)
+}
+
+func insertKeys() {
+	Insert("GOLANG", "001")
+	Insert("LANGGO", "100")
+	Insert("GO", "002")
+	Insert("HASH", "003")
+}
+
+func TestGetValueFromBucket(t *testing.T) {
+	golangValue:= GetValueFromBucket("GOLANG")
+	if golangValue != "001" {
+		t.Errorf("Value for GOLANG should be 001, got value = %v", golangValue)
+	}
+	langgoValue:= GetValueFromBucket("LANGGO")
+	if langgoValue != "100" {
+		t.Errorf("Value for GOLANG should be 100, got value = %v", langgoValue)
+	}
+	goValue:= GetValueFromBucket("GO")
+	if goValue != "002" {
+		t.Errorf("Value for GOLANG should be 002, got value = %v", goValue)
+	}
+	hashValue:= GetValueFromBucket("HASH")
+	if hashValue != "003" {
+		t.Errorf("Value for GOLANG should be 003, got value = %v", hashValue)
+	}
+}


### PR DESCRIPTION
### Hash Table

Key - value pairs are stored using a hash table. Hash function sums the rune values of the key to an integer less than 100.
Each bucket is a linked list, with the key and value stored to handle collisions. 
Equal key values will be mutated.

feat: add hash table
test: add tests for hash table

### Gif
![prV1](https://user-images.githubusercontent.com/62387714/95109394-2c807800-075a-11eb-84f6-5e614673526e.gif)


Signed-off-by: christin <christin@wednesday.is>